### PR TITLE
Remove the second row led calls and automatically find the sibling led by calculation

### DIFF
--- a/Code/Code.ino
+++ b/Code/Code.ino
@@ -538,9 +538,7 @@ void ShowIPaddress() {
   numbers(getDigit(int(WiFi.localIP()[0]), 1), 2);
   numbers(getDigit(int(WiFi.localIP()[0]), 0), 1);
   setLED(160, 160, 1);
-  setLED(191, 191, 1);  // 2nd row
   setLED(236, 239, 1);
-  setLED(240, 243, 1);  // 2nd row
   strip.show();
   delay(ipdelay);
 
@@ -550,9 +548,7 @@ void ShowIPaddress() {
   numbers(getDigit(int(WiFi.localIP()[1]), 1), 2);
   numbers(getDigit(int(WiFi.localIP()[1]), 0), 1);
   setLED(160, 160, 1);
-  setLED(191, 191, 1);  // 2nd row
   setLED(232, 239, 1);
-  setLED(240, 247, 1);  // 2nd row
   strip.show();
   delay(ipdelay);
 
@@ -562,9 +558,7 @@ void ShowIPaddress() {
   numbers(getDigit(int(WiFi.localIP()[2]), 1), 2);
   numbers(getDigit(int(WiFi.localIP()[2]), 0), 1);
   setLED(160, 160, 1);
-  setLED(191, 191, 1);  // 2nd row
   setLED(228, 239, 1);
-  setLED(240, 251, 1);  // 2nd row
   strip.show();
   delay(ipdelay);
 
@@ -574,7 +568,6 @@ void ShowIPaddress() {
   numbers(getDigit(int(WiFi.localIP()[3]), 1), 2);
   numbers(getDigit(int(WiFi.localIP()[3]), 0), 1);
   setLED(224, 239, 1);
-  setLED(240, 255, 1);  // 2nd row
   strip.show();
   delay(ipdelay);
 }
@@ -594,159 +587,100 @@ void numbers(int wert, int segment) {
           case 0:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 108, 1);
-              setLED(115, 115, 1);  // 2nd row
               setLED(111, 111, 1);
-              setLED(112, 112, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(143, 143, 1);
-              setLED(144, 144, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 1:
             {
               setLED(44, 44, 1);
-              setLED(51, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(108, 108, 1);
-              setLED(115, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 172, 1);
-              setLED(179, 179, 1);  // 2nd row
               break;
             }
           case 2:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(143, 143, 1);
-              setLED(144, 144, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 3:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 4:
             {
               setLED(44, 44, 1);
-              setLED(51, 51, 1);  // 2nd row
               setLED(47, 47, 1);
-              setLED(48, 48, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 172, 1);
-              setLED(179, 179, 1);  // 2nd row
               break;
             }
           case 5:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 6:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(143, 143, 1);
-              setLED(144, 144, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 7:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(108, 108, 1);
-              setLED(115, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 172, 1);
-              setLED(179, 179, 1);  // 2nd row
               break;
             }
           case 8:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(143, 143, 1);
-              setLED(144, 144, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
           case 9:
             {
               setLED(44, 47, 1);
-              setLED(48, 51, 1);  // 2nd row
               setLED(76, 76, 1);
-              setLED(83, 83, 1);  // 2nd row
               setLED(79, 79, 1);
-              setLED(80, 80, 1);  // 2nd row
               setLED(108, 111, 1);
-              setLED(112, 115, 1);  // 2nd row
               setLED(140, 140, 1);
-              setLED(147, 147, 1);  // 2nd row
               setLED(172, 175, 1);
-              setLED(176, 179, 1);  // 2nd row
               break;
             }
         }
@@ -759,159 +693,100 @@ void numbers(int wert, int segment) {
           case 0:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 103, 1);
-              setLED(120, 120, 1);  // 2nd row
               setLED(106, 106, 1);
-              setLED(117, 117, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(138, 138, 1);
-              setLED(149, 149, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 1:
             {
               setLED(39, 39, 1);
-              setLED(56, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(103, 103, 1);
-              setLED(120, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 167, 1);
-              setLED(184, 184, 1);  // 2nd row
               break;
             }
           case 2:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(138, 138, 1);
-              setLED(149, 149, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 3:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 4:
             {
               setLED(39, 39, 1);
-              setLED(56, 56, 1);  // 2nd row
               setLED(42, 42, 1);
-              setLED(53, 53, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 167, 1);
-              setLED(184, 184, 1);  // 2nd row
               break;
             }
           case 5:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 6:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(138, 138, 1);
-              setLED(149, 149, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 7:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(103, 103, 1);
-              setLED(120, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 167, 1);
-              setLED(184, 184, 1);  // 2nd row
               break;
             }
           case 8:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(138, 138, 1);
-              setLED(149, 149, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
           case 9:
             {
               setLED(39, 42, 1);
-              setLED(53, 56, 1);  // 2nd row
               setLED(71, 71, 1);
-              setLED(88, 88, 1);  // 2nd row
               setLED(74, 74, 1);
-              setLED(85, 85, 1);  // 2nd row
               setLED(103, 106, 1);
-              setLED(117, 120, 1);  // 2nd row
               setLED(135, 135, 1);
-              setLED(152, 152, 1);  // 2nd row
               setLED(167, 170, 1);
-              setLED(181, 184, 1);  // 2nd row
               break;
             }
         }
@@ -924,159 +799,100 @@ void numbers(int wert, int segment) {
           case 0:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 98, 1);
-              setLED(125, 125, 1);  // 2nd row
               setLED(101, 101, 1);
-              setLED(122, 122, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(133, 133, 1);
-              setLED(154, 154, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 1:
             {
               setLED(34, 34, 1);
-              setLED(61, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(98, 98, 1);
-              setLED(125, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 162, 1);
-              setLED(189, 189, 1);  // 2nd row
               break;
             }
           case 2:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(133, 133, 1);
-              setLED(154, 154, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 3:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 4:
             {
               setLED(34, 34, 1);
-              setLED(61, 61, 1);  // 2nd row
               setLED(37, 37, 1);
-              setLED(58, 58, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 162, 1);
-              setLED(189, 189, 1);  // 2nd row
               break;
             }
           case 5:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 6:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(133, 133, 1);
-              setLED(154, 154, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 7:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(98, 98, 1);
-              setLED(125, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 162, 1);
-              setLED(189, 189, 1);  // 2nd row
               break;
             }
           case 8:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(133, 133, 1);
-              setLED(154, 154, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
           case 9:
             {
               setLED(34, 37, 1);
-              setLED(58, 61, 1);  // 2nd row
               setLED(66, 66, 1);
-              setLED(93, 93, 1);  // 2nd row
               setLED(69, 69, 1);
-              setLED(90, 90, 1);  // 2nd row
               setLED(98, 101, 1);
-              setLED(122, 125, 1);  // 2nd row
               setLED(130, 130, 1);
-              setLED(157, 157, 1);  // 2nd row
               setLED(162, 165, 1);
-              setLED(186, 189, 1);  // 2nd row
               break;
             }
         }
@@ -1148,13 +964,9 @@ void buttonUpdate(Control* sender, int type, void* param) {
     showtext("T", TextWait, c);
     showtext("E", TextWait, c);
     setLED(0, 0, 1);
-    setLED(31, 31, 1);  // 2nd row
     setLED(15, 15, 1);
-    setLED(16, 16, 1);  // 2nd row
     setLED(239, 239, 1);
-    setLED(240, 240, 1);  // 2nd row
     setLED(224, 224, 1);
-    setLED(255, 255, 1);  // 2nd row
     int myArray[50];
     memset(myArray, 0, sizeof(myArray));
     int myArray2[] = { 42, 53, 74, 85, 106, 117, 138, 149, 170, 181, 169, 182, 183, 168, 167, 184, 166, 185, 186, 165, 154, 133, 122, 101, 90, 69, 58, 37 };  // U
@@ -1180,86 +992,59 @@ void ResetTextLEDs(uint32_t color) {
 
   if (langLEDlayout == 0) {      // DE:
     setLEDcol(137, 138, color);  // RE
-    setLEDcol(149, 150, color);  // 2nd row
     setLEDcol(167, 168, color);  // SE
-    setLEDcol(183, 184, color);  // 2nd row
     setLEDcol(227, 227, color);  // T
-    setLEDcol(252, 252, color);  // 2nd row
   }
 
   if (langLEDlayout == 1) {      // EN:
     setLEDcol(100, 101, color);  // RE
-    setLEDcol(122, 123, color);  // 2nd row
     setLEDcol(174, 175, color);  // SE
-    setLEDcol(176, 177, color);  // 2nd row
     setLEDcol(227, 227, color);  // T
-    setLEDcol(252, 252, color);  // 2nd row
   }
 
   if (langLEDlayout == 2) {      // NL:
     setLEDcol(33, 33, color);    // R
-    setLEDcol(62, 62, color);    // 2nd row
     setLEDcol(96, 97, color);    // ES
-    setLEDcol(126, 127, color);  // 2nd row
     setLEDcol(164, 164, color);  // E
-    setLEDcol(187, 187, color);  // 2nd row
     setLEDcol(227, 227, color);  // T
-    setLEDcol(252, 252, color);  // 2nd row
   }
 
   if (langLEDlayout == 3) {    // SWE:
     setLEDcol(67, 71, color);  // R
-    setLEDcol(88, 92, color);  // 2nd row
   }
 
   if (langLEDlayout == 4) {    // IT:
     setLEDcol(11, 11, color);  // R
-    setLEDcol(20, 20, color);  // 2nd row
     setLEDcol(9, 9, color);    // E
-    setLEDcol(22, 22, color);  // 2nd row
     setLEDcol(45, 47, color);  // SET
-    setLEDcol(48, 50, color);  // 2nd row
   }
 
   if (langLEDlayout == 5) {    // FR:
     setLEDcol(11, 13, color);  // RES
-    setLEDcol(18, 20, color);  // 2nd row
     setLEDcol(5, 5, color);    // E
-    setLEDcol(26, 26, color);  // 2nd row
     setLEDcol(36, 36, color);  // T
-    setLEDcol(59, 59, color);  // 2nd row
   }
 
   if (langLEDlayout == 6) {    // GSW:
     setLEDcol(11, 15, color);  // RESET
-    setLEDcol(16, 20, color);  // 2nd row
   }
 
   if (langLEDlayout == 7) {    // CN:
     setLEDcol(38, 39, color);  // RESET 重置
-    setLEDcol(56, 57, color);  // 2nd row
   }
 
   if (langLEDlayout == 8) {      // SWABIAN GERMAN:
     setLEDcol(40, 41, color);    // RE
-    setLEDcol(54, 55, color);    // 2nd row
     setLEDcol(133, 134, color);  // SE
-    setLEDcol(153, 154, color);  // 2nd row
     setLEDcol(204, 204, color);  // T
-    setLEDcol(211, 211, color);  // 2nd row
   }
 
   if (langLEDlayout == 9) {      // BAVARIAN:
     setLEDcol(106, 106, color);  // R
-    setLEDcol(117, 117, color);  // 2nd row
     setLEDcol(133, 133, color);  // E
-    setLEDcol(154, 154, color);  // 2nd row
     setLEDcol(175, 175, color);  // S
-    setLEDcol(176, 176, color);  // 2nd row
     setLEDcol(170, 170, color);  // E
-    setLEDcol(181, 181, color);  // 2nd row
     setLEDcol(160, 160, color);  // T
-    setLEDcol(191, 191, color);  // 2nd row
   }
 
   strip.show();
@@ -1532,9 +1317,7 @@ void show_time(int hours, int minutes) {
 
     // ES IST:
     setLEDcol(14, 15, colorRGB);
-    setLEDcol(16, 17, colorRGB);  // 2nd row
     setLEDcol(10, 12, colorRGB);
-    setLEDcol(19, 21, colorRGB);  // 2nd row
     if (testPrintTimeTexts == 1) {
       Serial.println("");
       Serial.print(hours);
@@ -1546,43 +1329,36 @@ void show_time(int hours, int minutes) {
     // FÜNF: (Minuten)
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(76, 79, colorRGB);
-      setLEDcol(80, 83, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("FÜNF ");
     }
     // VIERTEL:
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(69, 75, colorRGB);
-      setLEDcol(84, 90, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VIERTEL ");
     }
     // ZEHN: (Minuten)
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(32, 35, colorRGB);
-      setLEDcol(60, 63, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("ZEHN ");
     }
     // ZWANZIG:
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(41, 47, colorRGB);
-      setLEDcol(48, 54, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("ZWANZIG ");
     }
     // NACH:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 7)) {
       setLEDcol(64, 67, colorRGB);
-      setLEDcol(92, 95, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("NACH ");
     }
     // VOR:
     if ((minDiv == 5) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(109, 111, colorRGB);
-      setLEDcol(112, 114, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VOR ");
     }
     // HALB:
     if ((minDiv == 5) || (minDiv == 6) || (minDiv == 7)) {
       setLEDcol(104, 107, colorRGB);
-      setLEDcol(116, 119, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("HALB ");
     }
 
@@ -1606,12 +1382,10 @@ void show_time(int hours, int minutes) {
         {
           if (xHour == 1) {
             setLEDcol(169, 171, colorRGB);  // EIN
-            setLEDcol(180, 182, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("EIN ");
           }
           if ((xHour == 1) && (iMinute > 4)) {
             setLEDcol(168, 171, colorRGB);  // EINS (S in EINS) (just used if not point 1 o'clock)
-            setLEDcol(180, 183, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("EINS ");
           }
           break;
@@ -1619,77 +1393,66 @@ void show_time(int hours, int minutes) {
       case 2:
         {
           setLEDcol(140, 143, colorRGB);  // ZWEI
-          setLEDcol(144, 147, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZWEI ");
           break;
         }
       case 3:
         {
           setLEDcol(136, 139, colorRGB);  // DREI
-          setLEDcol(148, 151, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DREI ");
           break;
         }
       case 4:
         {
           setLEDcol(128, 131, colorRGB);  // VIER
-          setLEDcol(156, 159, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("VIER ");
           break;
         }
       case 5:
         {
           setLEDcol(160, 163, colorRGB);  // FUENF
-          setLEDcol(188, 191, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("FÜNF ");
           break;
         }
       case 6:
         {
           setLEDcol(164, 168, colorRGB);  // SECHS
-          setLEDcol(183, 187, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SECHS ");
           break;
         }
       case 7:
         {
           setLEDcol(202, 207, colorRGB);  // SIEBEN
-          setLEDcol(208, 213, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SIEBEN ");
           break;
         }
       case 8:
         {
           setLEDcol(172, 175, colorRGB);  // ACHT
-          setLEDcol(176, 179, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ACHT ");
           break;
         }
       case 9:
         {
           setLEDcol(132, 135, colorRGB);  // NEUN
-          setLEDcol(152, 155, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("NEUN ");
           break;
         }
       case 10:
         {
           setLEDcol(99, 102, colorRGB);   // ZEHN (Stunden)
-          setLEDcol(121, 124, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZEHN ");
           break;
         }
       case 11:
         {
           setLEDcol(96, 98, colorRGB);    // ELF
-          setLEDcol(125, 127, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ELF ");
           break;
         }
       case 12:
         {
           setLEDcol(197, 201, colorRGB);  // ZWÖLF
-          setLEDcol(214, 218, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZWÖLF ");
           break;
         }
@@ -1697,7 +1460,6 @@ void show_time(int hours, int minutes) {
 
     if (iMinute < 5) {
       setLEDcol(192, 194, colorRGB);  // UHR
-      setLEDcol(221, 223, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("UHR ");
     }
   }
@@ -1707,49 +1469,39 @@ void show_time(int hours, int minutes) {
 
     // IT IS:
     setLEDcol(14, 15, colorRGB);
-    setLEDcol(16, 17, colorRGB);  // 2nd row
     setLEDcol(11, 12, colorRGB);
-    setLEDcol(19, 20, colorRGB);  // 2nd row
 
     // FIVE: (Minutes)                         // x:05 + x:25 + x:35 + x:55
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(38, 41, colorRGB);
-      setLEDcol(54, 57, colorRGB);  // 2nd row
     }
     // QUARTER:                                // x:15 + X:45
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(72, 78, colorRGB);
-      setLEDcol(81, 87, colorRGB);  // 2nd row
     }
     // A:
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(5, 5, colorRGB);
-      setLEDcol(26, 26, colorRGB);  // 2nd row
     }
     // TEN: (Minutes)                          // x:10 + x:50
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(0, 2, colorRGB);
-      setLEDcol(29, 31, colorRGB);  // 2nd row
     }
     // TWENTY:                                 // x:20 + x:25 + x:35 + x:40
     if ((minDiv == 4) || (minDiv == 5) || (minDiv == 7) || (minDiv == 8)) {
       setLEDcol(42, 47, colorRGB);
-      setLEDcol(48, 53, colorRGB);  // 2nd row
     }
     // PAST:                                   // x:05 + x:10 + x:15 + x:20 + x:25 + x:30
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 5) || (minDiv == 6)) {
       setLEDcol(66, 69, colorRGB);
-      setLEDcol(90, 93, colorRGB);  // 2nd row
     }
     // TO:                                     // x:35 + x:40 + x:45 + x:50 + x:55
     if ((minDiv == 7) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(65, 66, colorRGB);
-      setLEDcol(93, 94, colorRGB);  // 2nd row
     }
     // HALF:                                   // x:30
     if ((minDiv == 6)) {
       setLEDcol(3, 6, colorRGB);
-      setLEDcol(25, 28, colorRGB);  // 2nd row
     }
 
 
@@ -1771,80 +1523,67 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(201, 203, colorRGB);  // ONE
-          setLEDcol(212, 214, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(105, 107, colorRGB);  // TWO
-          setLEDcol(116, 118, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(99, 103, colorRGB);   // THREE
-          setLEDcol(120, 124, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(128, 131, colorRGB);  // FOUR
-          setLEDcol(156, 159, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(108, 111, colorRGB);  // FIVE
-          setLEDcol(112, 115, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(163, 165, colorRGB);  // SIX
-          setLEDcol(186, 188, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(171, 175, colorRGB);  // SEVEN
-          setLEDcol(176, 180, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(166, 170, colorRGB);  // EIGHT
-          setLEDcol(181, 185, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(204, 207, colorRGB);  // NINE
-          setLEDcol(208, 211, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(96, 98, colorRGB);    // TEN
-          setLEDcol(125, 127, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(138, 143, colorRGB);  // ELEVEN
-          setLEDcol(144, 149, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           setLEDcol(132, 137, colorRGB);  // TWELVE
-          setLEDcol(150, 155, colorRGB);  // 2nd row
           break;
         }
     }
 
     if (iMinute < 5) {
       setLEDcol(193, 199, colorRGB);  // O'CLOCK
-      setLEDcol(216, 222, colorRGB);  // 2nd row
     }
   }
 
@@ -1853,44 +1592,34 @@ void show_time(int hours, int minutes) {
 
     // HET IS:
     setLEDcol(13, 15, colorRGB);
-    setLEDcol(16, 18, colorRGB);  // 2nd row
     setLEDcol(10, 11, colorRGB);
-    setLEDcol(20, 21, colorRGB);  // 2nd row
-
     // VIJF: (Minuten) x:05, x:25, x:35, x:55
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(0, 3, colorRGB);
-      setLEDcol(28, 31, colorRGB);  // 2nd row
     }
     // KWART: x:15, x:45
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(38, 42, colorRGB);
-      setLEDcol(53, 57, colorRGB);  // 2nd row
     }
     // TIEN: (Minuten) x:10, x:50
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(44, 47, colorRGB);
-      setLEDcol(48, 51, colorRGB);  // 2nd row
     }
     // TIEN: (TIEN VOOR HALF, TIEN OVER HALF) x:20, x:40 (on request not set to TWINTIG OVER)
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(44, 47, colorRGB);
-      setLEDcol(48, 51, colorRGB);  // 2nd row
     }
     // OVER: x:05, x:10, x:15, x:35, x:40
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 7) || (minDiv == 8)) {
       setLEDcol(33, 36, colorRGB);
-      setLEDcol(59, 62, colorRGB);  // 2nd row
     }
     // VOOR: x:20, x:25, x:45, x:50, x:55
     if ((minDiv == 4) || (minDiv == 5) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(64, 67, colorRGB);
-      setLEDcol(92, 95, colorRGB);  // 2nd row
     }
     // HALF:
     if ((minDiv == 4) || (minDiv == 5) || (minDiv == 6) || (minDiv == 7) || (minDiv == 8)) {
       setLEDcol(107, 110, colorRGB);
-      setLEDcol(113, 116, colorRGB);  // 2nd row
     }
 
 
@@ -1912,80 +1641,67 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(99, 101, colorRGB);   // EEN
-          setLEDcol(122, 124, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(203, 206, colorRGB);  // TWEE
-          setLEDcol(209, 212, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(164, 167, colorRGB);  // DRIE
-          setLEDcol(184, 187, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(198, 201, colorRGB);  // VIER
-          setLEDcol(214, 217, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(160, 163, colorRGB);  // VIJF
-          setLEDcol(188, 191, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(96, 98, colorRGB);    // ZES
-          setLEDcol(125, 127, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(129, 133, colorRGB);  // ZEVEN
-          setLEDcol(154, 158, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(102, 105, colorRGB);  // ACHT
-          setLEDcol(118, 121, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(171, 175, colorRGB);  // NEGEN
-          setLEDcol(176, 180, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(140, 143, colorRGB);  // TIEN (Stunden)
-          setLEDcol(144, 147, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(168, 170, colorRGB);  // ELF
-          setLEDcol(181, 183, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           setLEDcol(134, 139, colorRGB);  // TWAALF
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
     }
 
     if (iMinute < 5) {
       setLEDcol(193, 195, colorRGB);  // UUR
-      setLEDcol(220, 222, colorRGB);  // 2nd row
     }
   }
 
@@ -1994,44 +1710,34 @@ void show_time(int hours, int minutes) {
 
     // KLOCKAN ÄR:
     setLEDcol(9, 15, colorRGB);
-    setLEDcol(16, 22, colorRGB);  // 2nd row
     setLEDcol(5, 6, colorRGB);
-    setLEDcol(25, 26, colorRGB);  // 2nd row
-
     // FEM: (Minuten)
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(64, 66, colorRGB);
-      setLEDcol(93, 95, colorRGB);  // 2nd row
     }
     // KVART:
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(36, 40, colorRGB);
-      setLEDcol(55, 59, colorRGB);  // 2nd row
     }
     // TIO: (Minuten)
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(72, 74, colorRGB);
-      setLEDcol(85, 87, colorRGB);  // 2nd row
     }
     // TJUGO:
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(75, 79, colorRGB);
-      setLEDcol(80, 84, colorRGB);  // 2nd row
     }
     // ÖVER:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 7)) {
       setLEDcol(108, 111, colorRGB);
-      setLEDcol(112, 115, colorRGB);  // 2nd row
     }
     // I:
     if ((minDiv == 5) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(97, 97, colorRGB);
-      setLEDcol(126, 126, colorRGB);  // 2nd row
     }
     // HALV:
     if ((minDiv == 5) || (minDiv == 6) || (minDiv == 7)) {
       setLEDcol(140, 143, colorRGB);
-      setLEDcol(144, 147, colorRGB);  // 2nd row
     }
 
 
@@ -2054,74 +1760,62 @@ void show_time(int hours, int minutes) {
         {
           if (xHour == 1) {
             setLEDcol(170, 172, colorRGB);  // ETT
-            setLEDcol(179, 181, colorRGB);  // 2nd row
           }
           break;
         }
       case 2:
         {
           setLEDcol(160, 162, colorRGB);  // TVÅ
-          setLEDcol(189, 191, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(132, 134, colorRGB);  // TRE
-          setLEDcol(153, 155, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(197, 200, colorRGB);  // FYRA
-          setLEDcol(218, 218, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(194, 196, colorRGB);  // FEM
-          setLEDcol(219, 221, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(201, 203, colorRGB);  // SEX
-          setLEDcol(212, 214, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(173, 175, colorRGB);  // SJU
-          setLEDcol(176, 178, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(128, 131, colorRGB);  // ÅTTA
-          setLEDcol(156, 159, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(135, 137, colorRGB);  // NIO
-          setLEDcol(150, 152, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(168, 170, colorRGB);  // TIO (Stunden)
-          setLEDcol(181, 183, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(204, 207, colorRGB);  // ELVA
-          setLEDcol(208, 211, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           setLEDcol(163, 166, colorRGB);  // TOLV
-          setLEDcol(185, 188, colorRGB);  // 2nd row
           break;
         }
     }
@@ -2145,9 +1839,7 @@ void show_time(int hours, int minutes) {
     // SONO LE:
     if (xHour > 1) {                // NOTE: Displayed only from 2 to 23
       setLEDcol(9, 10, colorRGB);   // LE
-      setLEDcol(21, 22, colorRGB);  // 2nd row
       setLEDcol(12, 15, colorRGB);  // SONO
-      setLEDcol(16, 19, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) {
         Serial.println("");
         Serial.print(hours);
@@ -2161,86 +1853,73 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(0, 0, colorRGB);      // È
-          setLEDcol(31, 31, colorRGB);    // 2nd row
           setLEDcol(104, 108, colorRGB);  // L’UNA
-          setLEDcol(115, 119, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("È L’UNA ");
           break;
         }
       case 2:
         {
           setLEDcol(101, 103, colorRGB);  // DUE
-          setLEDcol(120, 122, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DUE ");
           break;
         }
       case 3:
         {
           setLEDcol(109, 111, colorRGB);  // TRE
-          setLEDcol(112, 114, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("TRE ");
           break;
         }
       case 4:
         {
           setLEDcol(73, 79, colorRGB);  // QUATTRO
-          setLEDcol(80, 86, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("QUATTRO ");
           break;
         }
       case 5:
         {
           setLEDcol(64, 69, colorRGB);  // CINQUE
-          setLEDcol(90, 95, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("CINQUE ");
           break;
         }
       case 6:
         {
           setLEDcol(40, 42, colorRGB);  // SEI
-          setLEDcol(53, 55, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SEI ");
           break;
         }
       case 7:
         {
           setLEDcol(43, 47, colorRGB);  // SETTE
-          setLEDcol(48, 52, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SETTE ");
           break;
         }
       case 8:
         {
           setLEDcol(70, 73, colorRGB);  // OTTO
-          setLEDcol(86, 89, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("OTTO ");
           break;
         }
       case 9:
         {
           setLEDcol(97, 100, colorRGB);   // NOVE
-          setLEDcol(123, 126, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("NOVE ");
           break;
         }
       case 10:
         {
           setLEDcol(138, 142, colorRGB);  // DIECI
-          setLEDcol(145, 149, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DIECI ");
           break;
         }
       case 11:
         {
           setLEDcol(1, 6, colorRGB);    // UNDICI
-          setLEDcol(25, 30, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("UNDICI ");
           break;
         }
       case 12:
         {
           setLEDcol(34, 39, colorRGB);  // DODICI
-          setLEDcol(56, 61, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DODICI ");
           break;
         }
@@ -2249,57 +1928,47 @@ void show_time(int hours, int minutes) {
     // E:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 5) || (minDiv == 6) || (minDiv == 7)) {
       setLEDcol(134, 134, colorRGB);
-      setLEDcol(153, 153, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("E ");
     }
     // MENO:
     if ((minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(132, 135, colorRGB);
-      setLEDcol(152, 155, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("MENO ");
     }
     // 5/55: CINQUE
     if ((minDiv == 1) || (minDiv == 11)) {
       setLEDcol(162, 167, colorRGB);
-      setLEDcol(184, 189, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("CINQUE ");
     }
     // 15/45: UN QUARTO
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(128, 129, colorRGB);  // UN
-      setLEDcol(158, 159, colorRGB);  // 2nd row
       setLEDcol(234, 239, colorRGB);  // QUARTO
-      setLEDcol(240, 245, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("UN QUARTO ");
     }
     // 10/50: DIECI
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(192, 196, colorRGB);
-      setLEDcol(219, 223, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("DIECI ");
     }
     // 20/40: VENTI
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(203, 207, colorRGB);
-      setLEDcol(208, 212, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VENTI ");
     }
     // 25: VENTICINQUE
     if (minDiv == 5) {
       setLEDcol(197, 207, colorRGB);
-      setLEDcol(208, 218, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VENTICINQUE ");
     }
     // 30: TRENTA
     if (minDiv == 6) {
       setLEDcol(168, 173, colorRGB);
-      setLEDcol(178, 183, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("TRENTA ");
     }
     // 35: TRENTACINQUE
     if (minDiv == 7) {
       setLEDcol(162, 173, colorRGB);
-      setLEDcol(178, 189, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("TRENTACINQUE ");
     }
   }
@@ -2309,55 +1978,41 @@ void show_time(int hours, int minutes) {
 
     // IL EST:
     setLEDcol(14, 15, colorRGB);  // IL
-    setLEDcol(16, 17, colorRGB);  // 2nd row
     setLEDcol(10, 12, colorRGB);  // EST
-    setLEDcol(19, 21, colorRGB);  // 2nd row
-
     // CINQ: (Minutes) x:05, x:25, x:35, x:55
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(197, 200, colorRGB);
-      setLEDcol(215, 218, colorRGB);  // 2nd row
     }
     // ET QUART: x:15,
     if ((minDiv == 3)) {
       setLEDcol(171, 172, colorRGB);  // ET
-      setLEDcol(179, 180, colorRGB);  // 2nd row
       setLEDcol(193, 197, colorRGB);  // QUART
-      setLEDcol(218, 222, colorRGB);  // 2nd row
     }
     // LE QUART: x:45
     if ((minDiv == 9)) {
       setLEDcol(172, 173, colorRGB);  // LE
-      setLEDcol(178, 179, colorRGB);  // 2nd row
       setLEDcol(193, 197, colorRGB);  // QUART
-      setLEDcol(218, 222, colorRGB);  // 2nd row
     }
     // DIX: (Minutes) x:10, x:50
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(167, 169, colorRGB);
-      setLEDcol(182, 184, colorRGB);  // 2nd row
     }
     // VINGT: x:20, x:40
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(202, 206, colorRGB);
-      setLEDcol(209, 213, colorRGB);  // 2nd row
     }
     // VINGT-: x:25, x:35
     if ((minDiv == 5) || (minDiv == 7)) {
       setLEDcol(201, 206, colorRGB);
-      setLEDcol(209, 214, colorRGB);  // 2nd row
     }
     // MOINS: x:35, x:40 x:45, x:50, x:55
     if ((minDiv == 7) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(128, 132, colorRGB);
-      setLEDcol(155, 159, colorRGB);  // 2nd row
     }
     // ET DEMIE: x:30
     if ((minDiv == 6)) {
       setLEDcol(171, 172, colorRGB);  // ET
-      setLEDcol(179, 180, colorRGB);  // 2nd row
       setLEDcol(161, 165, colorRGB);  // DEMIE
-      setLEDcol(186, 190, colorRGB);  // 2nd row
     }
 
 
@@ -2378,98 +2033,74 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(141, 143, colorRGB);  // UNE
-          setLEDcol(144, 146, colorRGB);  // 2nd row
           setLEDcol(135, 139, colorRGB);  // HEURE
-          setLEDcol(148, 152, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(96, 99, colorRGB);    // DEUX
-          setLEDcol(124, 127, colorRGB);  // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(107, 111, colorRGB);  // TROIS
-          setLEDcol(112, 116, colorRGB);  // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(42, 47, colorRGB);    // QUATRE
-          setLEDcol(48, 53, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(1, 4, colorRGB);      // CINQ
-          setLEDcol(27, 30, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(64, 66, colorRGB);    // SIX
-          setLEDcol(93, 95, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(104, 107, colorRGB);  // SEPT
-          setLEDcol(116, 119, colorRGB);  // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(32, 35, colorRGB);    // HUIT
-          setLEDcol(60, 63, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(100, 103, colorRGB);  // NEUF
-          setLEDcol(120, 123, colorRGB);  // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(77, 79, colorRGB);    // DIX
-          setLEDcol(80, 82, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(5, 8, colorRGB);      // ONZE
-          setLEDcol(23, 26, colorRGB);    // 2nd row
           setLEDcol(134, 139, colorRGB);  // HEURES
-          setLEDcol(148, 153, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           // MINUIT (0) or MIDI (12)
           if (iHour == 0 || (iHour == 23 && iMinute >= 35)) setLEDcol(36, 41, colorRGB);   // MINUIT (0)
-          if (iHour == 0 || (iHour == 23 && iMinute >= 35)) setLEDcol(54, 59, colorRGB);   // 2nd row
           if (iHour == 12 || (iHour == 11 && iMinute >= 35)) setLEDcol(73, 76, colorRGB);  // MIDI (12)
-          if (iHour == 12 || (iHour == 11 && iMinute >= 35)) setLEDcol(83, 86, colorRGB);  // 2nd row
           break;
         }
     }
@@ -2480,44 +2111,34 @@ void show_time(int hours, int minutes) {
 
     // ES ISCH:
     setLEDcol(13, 14, colorRGB);  // ES
-    setLEDcol(17, 18, colorRGB);  // 2nd row
     setLEDcol(4, 7, colorRGB);    // ISCH
-    setLEDcol(24, 27, colorRGB);  // 2nd row
-
     // FÜÜF: (Minuten)
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(44, 47, colorRGB);
-      setLEDcol(48, 51, colorRGB);  // 2nd row
     }
     // VIERTEL:
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(72, 78, colorRGB);
-      setLEDcol(81, 87, colorRGB);  // 2nd row
     }
     // ZÄH: (Minuten)
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(34, 36, colorRGB);
-      setLEDcol(59, 61, colorRGB);  // 2nd row
     }
     // ZWÄNZG:
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(65, 70, colorRGB);
-      setLEDcol(89, 94, colorRGB);  // 2nd row
     }
     // AB:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 7)) {
       setLEDcol(110, 111, colorRGB);
-      setLEDcol(112, 113, colorRGB);  // 2nd row
     }
     // VOR:
     if ((minDiv == 5) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(107, 109, colorRGB);
-      setLEDcol(114, 116, colorRGB);  // 2nd row
     }
     // HALBI:
     if ((minDiv == 5) || (minDiv == 6) || (minDiv == 7)) {
       setLEDcol(101, 105, colorRGB);
-      setLEDcol(118, 122, colorRGB);  // 2nd row
     }
 
 
@@ -2539,73 +2160,61 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(128, 130, colorRGB);  // EIS
-          setLEDcol(157, 159, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(136, 139, colorRGB);  // ZWEI
-          setLEDcol(148, 151, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(96, 99, colorRGB);    // DRÜÜ
-          setLEDcol(124, 127, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(160, 164, colorRGB);  // VIERI
-          setLEDcol(187, 191, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(171, 175, colorRGB);  // FÜÜFI
-          setLEDcol(176, 180, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(165, 170, colorRGB);  // SÄCHSI
-          setLEDcol(181, 186, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(202, 207, colorRGB);  // SIEBNI
-          setLEDcol(208, 213, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(192, 196, colorRGB);  // ACHTI
-          setLEDcol(219, 223, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(131, 135, colorRGB);  // NÜÜNI
-          setLEDcol(152, 156, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(197, 201, colorRGB);  // ZÄHNI (Stunden)
-          setLEDcol(214, 218, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(140, 143, colorRGB);  // ELFI
-          setLEDcol(144, 147, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           setLEDcol(233, 238, colorRGB);  // ZWÖLFI
-          setLEDcol(241, 246, colorRGB);  // 2nd row
           break;
         }
     }
@@ -2616,64 +2225,50 @@ void show_time(int hours, int minutes) {
 
     // IT IS: 现在 时间
     setLEDcol(44, 45, colorRGB);
-    setLEDcol(50, 51, colorRGB);  // 2nd row
     setLEDcol(40, 41, colorRGB);
-    setLEDcol(54, 55, colorRGB);  // 2nd row
-
     // 零五分                         // x:05
     if ((minDiv == 1)) {
       setLEDcol(101, 103, colorRGB);
-      setLEDcol(120, 122, colorRGB);  // 2nd row
     }
     // 十分                         // x:10
     if ((minDiv == 2)) {
       setLEDcol(98, 99, colorRGB);
-      setLEDcol(124, 125, colorRGB);  // 2nd row
     }
     // 十五分                         // x:15
     if ((minDiv == 3)) {
       setLEDcol(138, 140, colorRGB);
-      setLEDcol(147, 149, colorRGB);  // 2nd row
     }
     // 二十分                         // x:20
     if ((minDiv == 4)) {
       setLEDcol(98, 100, colorRGB);
-      setLEDcol(123, 125, colorRGB);  // 2nd row
     }
     // 二十五分                         // x:25
     if ((minDiv == 5)) {
       setLEDcol(138, 141, colorRGB);
-      setLEDcol(146, 149, colorRGB);  // 2nd row
     }
     // 三十分                         // x:30
     if ((minDiv == 6)) {
       setLEDcol(135, 137, colorRGB);
-      setLEDcol(150, 152, colorRGB);  // 2nd row
     }
     // 三十五分                         // x:35
     if ((minDiv == 7)) {
       setLEDcol(170, 173, colorRGB);
-      setLEDcol(178, 181, colorRGB);  // 2nd row
     }
     // 四十分                         // x:40
     if ((minDiv == 8)) {
       setLEDcol(132, 134, colorRGB);
-      setLEDcol(153, 155, colorRGB);  // 2nd row
     }
     // 四十五分                         // x:45
     if ((minDiv == 9)) {
       setLEDcol(166, 169, colorRGB);
-      setLEDcol(182, 185, colorRGB);  // 2nd row
     }
     // 五十分                         // x:50
     if ((minDiv == 10)) {
       setLEDcol(163, 165, colorRGB);
-      setLEDcol(186, 188, colorRGB);  // 2nd row
     }
     // 五十五分                         // x:55
     if ((minDiv == 11)) {
       setLEDcol(202, 205, colorRGB);
-      setLEDcol(210, 213, colorRGB);  // 2nd row
     }
 
     //set hour from 1 to 12 (at noon, or midnight)
@@ -2687,80 +2282,67 @@ void show_time(int hours, int minutes) {
       case 1:
         {
           setLEDcol(75, 76, colorRGB);  // 一点
-          setLEDcol(83, 84, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(72, 73, colorRGB);  // 二点
-          setLEDcol(86, 87, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(36, 37, colorRGB);  // 三点
-          setLEDcol(58, 59, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(34, 35, colorRGB);  // 四点
-          setLEDcol(60, 61, colorRGB);  // 2nd row
           break;
         }
       case 5:
         {
           setLEDcol(70, 71, colorRGB);  // 五点
-          setLEDcol(88, 89, colorRGB);  // 2nd row
           break;
         }
       case 6:
         {
           setLEDcol(68, 69, colorRGB);  // 六点
-          setLEDcol(90, 91, colorRGB);  // 2nd row
           break;
         }
       case 7:
         {
           setLEDcol(66, 67, colorRGB);  // 七点
-          setLEDcol(92, 93, colorRGB);  // 2nd row
           break;
         }
       case 8:
         {
           setLEDcol(108, 109, colorRGB);  // 八点
-          setLEDcol(114, 115, colorRGB);  // 2nd row
           break;
         }
       case 9:
         {
           setLEDcol(106, 107, colorRGB);  // 九点
-          setLEDcol(116, 117, colorRGB);  // 2nd row
           break;
         }
       case 10:
         {
           setLEDcol(104, 105, colorRGB);  // 十点
-          setLEDcol(118, 119, colorRGB);  // 2nd row
           break;
         }
       case 11:
         {
           setLEDcol(75, 77, colorRGB);  // 十一点
-          setLEDcol(82, 84, colorRGB);  // 2nd row
           break;
         }
       case 12:
         {
           setLEDcol(72, 74, colorRGB);  // 十二点
-          setLEDcol(85, 87, colorRGB);  // 2nd row
           break;
         }
     }
 
     if (iMinute < 5) {
       setLEDcol(162, 162, colorRGB);  // 整
-      setLEDcol(189, 189, colorRGB);  // 2nd row
     }
   }
 
@@ -2769,9 +2351,7 @@ void show_time(int hours, int minutes) {
 
     // ES ISCH:
     setLEDcol(14, 15, colorRGB);
-    setLEDcol(16, 17, colorRGB);  // 2nd row
     setLEDcol(9, 12, colorRGB);
-    setLEDcol(19, 22, colorRGB);  // 2nd row
     if (testPrintTimeTexts == 1) {
       Serial.println("");
       Serial.print(hours);
@@ -2783,49 +2363,42 @@ void show_time(int hours, int minutes) {
     // FÜNF: (Minuten)
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(76, 79, colorRGB);
-      setLEDcol(80, 83, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("FÜNF ");
     }
 
     // VIERTL:
     if (minDiv == 3) {
       setLEDcol(0, 5, colorRGB);
-      setLEDcol(26, 31, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VIERTL ");
     }
 
     // DREIVIERTL:
     if (minDiv == 9) {
       setLEDcol(33, 42, colorRGB);
-      setLEDcol(53, 62, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("DREIVIERTL ");
     }
 
     // ZEHN: (Minuten)
     if ((minDiv == 2) || (minDiv == 4) || (minDiv == 8) || (minDiv == 10)) {
       setLEDcol(71, 74, colorRGB);
-      setLEDcol(85, 88, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("ZEHN ");
     }
 
     // NACH:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 7) || (minDiv == 8)) {
       setLEDcol(65, 68, colorRGB);
-      setLEDcol(91, 94, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("NACH ");
     }
 
     // VOR:
     if ((minDiv == 4) || (minDiv == 5) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(109, 111, colorRGB);
-      setLEDcol(112, 114, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VOR ");
     }
 
     // HALB:
     if ((minDiv == 4) || (minDiv == 5) || (minDiv == 6) || (minDiv == 7) || (minDiv == 8)) {
       setLEDcol(102, 105, colorRGB);
-      setLEDcol(118, 121, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("HALB ");
     }
 
@@ -2847,7 +2420,6 @@ void show_time(int hours, int minutes) {
         {
           if (xHour == 1) {
             setLEDcol(165, 168, colorRGB);  // OISE
-            setLEDcol(183, 186, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("OISE ");
           }
           break;
@@ -2855,77 +2427,66 @@ void show_time(int hours, int minutes) {
       case 2:
         {
           setLEDcol(160, 164, colorRGB);  // ZWOIE
-          setLEDcol(187, 191, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZWOIE ");
           break;
         }
       case 3:
         {
           setLEDcol(235, 239, colorRGB);  // DREIE
-          setLEDcol(240, 244, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DREIE ");
           break;
         }
       case 4:
         {
           setLEDcol(128, 132, colorRGB);  // VIERE
-          setLEDcol(155, 159, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("VIERE ");
           break;
         }
       case 5:
         {
           setLEDcol(139, 143, colorRGB);  // FÜNFE
-          setLEDcol(144, 148, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("FÜNFE ");
           break;
         }
       case 6:
         {
           setLEDcol(133, 138, colorRGB);  // SECHSE
-          setLEDcol(149, 154, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SECHSE ");
           break;
         }
       case 7:
         {
           setLEDcol(169, 175, colorRGB);  // SIEBENE
-          setLEDcol(176, 182, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("SIEBENE ");
           break;
         }
       case 8:
         {
           setLEDcol(203, 207, colorRGB);  // ACHTE
-          setLEDcol(208, 212, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ACHTE ");
           break;
         }
       case 9:
         {
           setLEDcol(192, 196, colorRGB);  // NEUNE
-          setLEDcol(219, 223, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("NEUNE ");
           break;
         }
       case 10:
         {
           setLEDcol(96, 100, colorRGB);   // ZEHNE (Stunden)
-          setLEDcol(123, 127, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZEHNE ");
           break;
         }
       case 11:
         {
           setLEDcol(232, 235, colorRGB);  // ELFE
-          setLEDcol(244, 247, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ELFE ");
           break;
         }
       case 12:
         {
           setLEDcol(197, 202, colorRGB);  // ZWÖLFE
-          setLEDcol(213, 218, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZWÖLFE ");
           break;
         }
@@ -2937,9 +2498,7 @@ void show_time(int hours, int minutes) {
 
     // ES IS:
     setLEDcol(14, 15, colorRGB);
-    setLEDcol(16, 17, colorRGB);  // 2nd row
     setLEDcol(9, 10, colorRGB);
-    setLEDcol(21, 22, colorRGB);  // 2nd row
     if (testPrintTimeTexts == 1) {
       Serial.println("");
       Serial.print(hours);
@@ -2951,49 +2510,42 @@ void show_time(int hours, int minutes) {
     // FÜNF: (Minuten)
     if ((minDiv == 1) || (minDiv == 5) || (minDiv == 7) || (minDiv == 11)) {
       setLEDcol(33, 36, colorRGB);
-      setLEDcol(59, 62, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("FÜNF ");
     }
 
     // VIERTL:
     if ((minDiv == 3) || (minDiv == 9)) {
       setLEDcol(37, 42, colorRGB);
-      setLEDcol(53, 58, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VIERTL ");
     }
 
     // ZWANZIG:
     if ((minDiv == 4) || (minDiv == 8)) {
       setLEDcol(72, 78, colorRGB);
-      setLEDcol(81, 87, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("ZWANZIG ");
     }
 
     // ZEHN: (Minuten)
     if ((minDiv == 2) || (minDiv == 10)) {
       setLEDcol(44, 47, colorRGB);
-      setLEDcol(48, 51, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("ZEHN ");
     }
 
     // NOCH:
     if ((minDiv == 1) || (minDiv == 2) || (minDiv == 3) || (minDiv == 4) || (minDiv == 7)) {
       setLEDcol(64, 67, colorRGB);
-      setLEDcol(92, 95, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("NOCH ");
     }
 
     // VOA:
     if ((minDiv == 5) || (minDiv == 8) || (minDiv == 9) || (minDiv == 10) || (minDiv == 11)) {
       setLEDcol(68, 70, colorRGB);
-      setLEDcol(89, 91, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("VOA ");
     }
 
     // HOIBE:
     if ((minDiv == 5) || (minDiv == 6) || (minDiv == 7)) {
       setLEDcol(107, 111, colorRGB);
-      setLEDcol(112, 116, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("HOIBE ");
     }
 
@@ -3015,7 +2567,6 @@ void show_time(int hours, int minutes) {
         {
           if (xHour == 1) {
             setLEDcol(102, 105, colorRGB);  // OANS
-            setLEDcol(118, 121, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("OANS ");
           }
           break;
@@ -3023,14 +2574,12 @@ void show_time(int hours, int minutes) {
       case 2:
         {
           setLEDcol(161, 164, colorRGB);  // ZWOA
-          setLEDcol(187, 190, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("ZWOA ");
           break;
         }
       case 3:
         {
           setLEDcol(165, 168, colorRGB);  // DREI
-          setLEDcol(183, 186, colorRGB);  // 2nd row
           if (testPrintTimeTexts == 1) Serial.print("DREI ");
           break;
         }
@@ -3038,11 +2587,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(194, 196, colorRGB);  // VIA
-            setLEDcol(219, 221, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("VIA ");
           } else {
             setLEDcol(192, 196, colorRGB);  // VIARE
-            setLEDcol(219, 223, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("VIARE ");
           }
           break;
@@ -3051,11 +2598,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(98, 101, colorRGB);   // FÜNF
-            setLEDcol(122, 125, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("FÜNF ");
           } else {
             setLEDcol(97, 101, colorRGB);   // FÜNFE
-            setLEDcol(122, 126, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("FÜNFE ");
           }
           break;
@@ -3064,11 +2609,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(203, 207, colorRGB);  // SECKS
-            setLEDcol(208, 212, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("SECKS ");
           } else {
             setLEDcol(202, 207, colorRGB);  // SECKSE
-            setLEDcol(208, 213, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("SECKSE ");
           }
           break;
@@ -3077,11 +2620,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(171, 175, colorRGB);  // SIEBN
-            setLEDcol(176, 180, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("SIEBN ");
           } else {
             setLEDcol(170, 175, colorRGB);  // SIEBNE
-            setLEDcol(176, 181, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("SIEBNE ");
           }
           break;
@@ -3090,11 +2631,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(129, 132, colorRGB);  // ACHT
-            setLEDcol(155, 158, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ACHT ");
           } else {
             setLEDcol(128, 132, colorRGB);  // ACHTE
-            setLEDcol(155, 159, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ACHTE ");
           }
           break;
@@ -3103,11 +2642,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(198, 201, colorRGB);  // NEIN
-            setLEDcol(214, 217, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("NEIN ");
           } else {
             setLEDcol(197, 201, colorRGB);  // NEINE
-            setLEDcol(214, 218, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("NEINE ");
           }
           break;
@@ -3116,11 +2653,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(134, 137, colorRGB);  // ZEHN (Stunden)
-            setLEDcol(150, 153, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ZEHN ");
           } else {
             setLEDcol(133, 137, colorRGB);  // ZEHNE (Stunden)
-            setLEDcol(150, 154, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ZEHNE ");
           }
           break;
@@ -3129,11 +2664,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(237, 239, colorRGB);  // EJF
-            setLEDcol(240, 242, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("EJF ");
           } else {
             setLEDcol(236, 239, colorRGB);  // EJFE
-            setLEDcol(240, 243, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("EJFE ");
           }
           break;
@@ -3142,11 +2675,9 @@ void show_time(int hours, int minutes) {
         {
           if (iMinute < 5) {
             setLEDcol(139, 143, colorRGB);  // ZWÄIF
-            setLEDcol(144, 148, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ZWÄIF ");
           } else {
             setLEDcol(138, 143, colorRGB);  // ZWÄIFE
-            setLEDcol(144, 149, colorRGB);  // 2nd row
             if (testPrintTimeTexts == 1) Serial.print("ZWÄIFE ");
           }
           break;
@@ -3155,7 +2686,6 @@ void show_time(int hours, int minutes) {
 
     if (iMinute < 5) {
       setLEDcol(232, 234, colorRGB);  // UAH
-      setLEDcol(245, 247, colorRGB);  // 2nd row
       if (testPrintTimeTexts == 1) Serial.print("UAH ");
     }
   }
@@ -3178,41 +2708,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(236, 236, colorRGB);  // 1
-          setLEDcol(243, 243, colorRGB);  // 2nd row
           setLEDcol(226, 231, colorRGB);  // MINUTE
-          setLEDcol(248, 253, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(235, 235, colorRGB);  // 2
-          setLEDcol(244, 244, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(234, 234, colorRGB);  // 3
-          setLEDcol(245, 245, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(233, 233, colorRGB);  // 4
-          setLEDcol(246, 246, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3224,41 +2742,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(236, 236, colorRGB);  // 1
-          setLEDcol(243, 243, colorRGB);  // 2nd row
           setLEDcol(226, 231, colorRGB);  // MINUTE
-          setLEDcol(248, 253, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(235, 235, colorRGB);  // 2
-          setLEDcol(244, 244, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(234, 234, colorRGB);  // 3
-          setLEDcol(245, 245, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(233, 233, colorRGB);  // 4
-          setLEDcol(246, 246, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3271,41 +2777,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(236, 236, colorRGB);  // 1
-          setLEDcol(243, 243, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN (set to this on request, because there was no space for the extra word "minuut")
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(235, 235, colorRGB);  // 2
-          setLEDcol(244, 244, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(234, 234, colorRGB);  // 3
-          setLEDcol(245, 245, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(233, 233, colorRGB);  // 4
-          setLEDcol(246, 246, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTEN
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3318,41 +2812,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(236, 236, colorRGB);  // 1
-          setLEDcol(243, 243, colorRGB);  // 2nd row
           setLEDcol(227, 231, colorRGB);  // MINUT
-          setLEDcol(248, 252, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(235, 235, colorRGB);  // 2
-          setLEDcol(244, 244, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTER
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(234, 234, colorRGB);  // 3
-          setLEDcol(245, 245, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTER
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(233, 233, colorRGB);  // 4
-          setLEDcol(246, 246, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTER
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3365,41 +2847,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(232, 232, colorRGB);  // +
-          setLEDcol(247, 247, colorRGB);  // 2nd row
           setLEDcol(230, 230, colorRGB);  // 1
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(225, 225, colorRGB);  // M
-          setLEDcol(254, 254, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(232, 232, colorRGB);  // +
-          setLEDcol(247, 247, colorRGB);  // 2nd row
           setLEDcol(229, 229, colorRGB);  // 2
-          setLEDcol(250, 250, colorRGB);  // 2nd row
           setLEDcol(225, 225, colorRGB);  // M
-          setLEDcol(254, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(232, 232, colorRGB);  // +
-          setLEDcol(247, 247, colorRGB);  // 2nd row
           setLEDcol(228, 228, colorRGB);  // 3
-          setLEDcol(251, 251, colorRGB);  // 2nd row
           setLEDcol(225, 225, colorRGB);  // M
-          setLEDcol(254, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(232, 232, colorRGB);  // +
-          setLEDcol(247, 247, colorRGB);  // 2nd row
           setLEDcol(227, 227, colorRGB);  // 4
-          setLEDcol(252, 252, colorRGB);  // 2nd row
           setLEDcol(225, 225, colorRGB);  // M
-          setLEDcol(254, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3411,41 +2881,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(236, 236, colorRGB);  // 1
-          setLEDcol(243, 243, colorRGB);  // 2nd row
           setLEDcol(226, 231, colorRGB);  // MINUTE
-          setLEDcol(248, 253, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(235, 235, colorRGB);  // 2
-          setLEDcol(244, 244, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(234, 234, colorRGB);  // 3
-          setLEDcol(245, 245, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(238, 238, colorRGB);  // +
-          setLEDcol(241, 241, colorRGB);  // 2nd row
           setLEDcol(233, 233, colorRGB);  // 4
-          setLEDcol(246, 246, colorRGB);  // 2nd row
           setLEDcol(225, 231, colorRGB);  // MINUTES
-          setLEDcol(248, 254, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3458,41 +2916,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(231, 231, colorRGB);  // +
-          setLEDcol(248, 248, colorRGB);  // 2nd row
           setLEDcol(229, 229, colorRGB);  // 1
-          setLEDcol(250, 250, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(231, 231, colorRGB);  // +
-          setLEDcol(248, 248, colorRGB);  // 2nd row
           setLEDcol(228, 228, colorRGB);  // 2
-          setLEDcol(251, 251, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(231, 231, colorRGB);  // +
-          setLEDcol(248, 248, colorRGB);  // 2nd row
           setLEDcol(227, 227, colorRGB);  // 3
-          setLEDcol(252, 252, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(231, 231, colorRGB);  // +
-          setLEDcol(248, 248, colorRGB);  // 2nd row
           setLEDcol(226, 226, colorRGB);  // 4
-          setLEDcol(253, 253, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3504,41 +2950,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(200, 200, colorRGB);  // 加
-          setLEDcol(215, 215, colorRGB);  // 2nd row
           setLEDcol(199, 199, colorRGB);  // 一
-          setLEDcol(216, 216, colorRGB);  // 2nd row
           setLEDcol(194, 195, colorRGB);  // 分钟
-          setLEDcol(220, 221, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(200, 200, colorRGB);  // 加
-          setLEDcol(215, 215, colorRGB);  // 2nd row
           setLEDcol(198, 198, colorRGB);  // 二
-          setLEDcol(217, 217, colorRGB);  // 2nd row
           setLEDcol(194, 195, colorRGB);  // 分钟
-          setLEDcol(220, 221, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(200, 200, colorRGB);  // 加
-          setLEDcol(215, 215, colorRGB);  // 2nd row
           setLEDcol(197, 197, colorRGB);  // 三
-          setLEDcol(218, 218, colorRGB);  // 2nd row
           setLEDcol(194, 195, colorRGB);  // 分钟
-          setLEDcol(220, 221, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(200, 200, colorRGB);  // 加
-          setLEDcol(215, 215, colorRGB);  // 2nd row
           setLEDcol(196, 196, colorRGB);  // 四
-          setLEDcol(219, 219, colorRGB);  // 2nd row
           setLEDcol(194, 195, colorRGB);  // 分钟
-          setLEDcol(220, 221, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3551,41 +2985,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(229, 229, colorRGB);  // 1
-          setLEDcol(250, 250, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(228, 228, colorRGB);  // 2
-          setLEDcol(251, 251, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(227, 227, colorRGB);  // 3
-          setLEDcol(252, 252, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(226, 226, colorRGB);  // 4
-          setLEDcol(253, 253, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3598,41 +3020,29 @@ void showMinutes(int minutes) {
       case 1:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(229, 229, colorRGB);  // 1
-          setLEDcol(250, 250, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 2:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(228, 228, colorRGB);  // 2
-          setLEDcol(251, 251, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 3:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(227, 227, colorRGB);  // 3
-          setLEDcol(252, 252, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
       case 4:
         {
           setLEDcol(230, 230, colorRGB);  // +
-          setLEDcol(249, 249, colorRGB);  // 2nd row
           setLEDcol(226, 226, colorRGB);  // 4
-          setLEDcol(253, 253, colorRGB);  // 2nd row
           setLEDcol(224, 224, colorRGB);  // M
-          setLEDcol(255, 255, colorRGB);  // 2nd row
           break;
         }
     }
@@ -3702,68 +3112,50 @@ void initTime(String timezone) {
 
     if (langLEDlayout == 0) {  // DE:
       setLEDcol(1, 4, strip.Color(255, 0, 0));
-      setLEDcol(27, 30, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 1) {  // EN:
       setLEDcol(33, 36, strip.Color(255, 0, 0));
-      setLEDcol(59, 62, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 2) {  // NL:
       setLEDcol(69, 72, strip.Color(255, 0, 0));
-      setLEDcol(87, 90, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 3) {  // SWE:
       setLEDcol(96, 98, strip.Color(255, 0, 0));
-      setLEDcol(125, 127, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 4) {                       // IT:
       setLEDcol(111, 111, strip.Color(255, 0, 0));  // T
-      setLEDcol(112, 112, strip.Color(255, 0, 0));  // 2nd row
       setLEDcol(96, 97, strip.Color(255, 0, 0));    // EM
-      setLEDcol(126, 127, strip.Color(255, 0, 0));  // 2nd row
       setLEDcol(131, 131, strip.Color(255, 0, 0));  // P
-      setLEDcol(156, 156, strip.Color(255, 0, 0));  // 2nd row
       setLEDcol(234, 234, strip.Color(255, 0, 0));  // O
-      setLEDcol(245, 245, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 5) {                       // FR:
       setLEDcol(10, 10, strip.Color(255, 0, 0));    // T
-      setLEDcol(21, 21, strip.Color(255, 0, 0));    // 2nd row
       setLEDcol(41, 42, strip.Color(255, 0, 0));    // EM
-      setLEDcol(53, 54, strip.Color(255, 0, 0));    // 2nd row
       setLEDcol(105, 105, strip.Color(255, 0, 0));  // p
-      setLEDcol(118, 118, strip.Color(255, 0, 0));  // 2nd row
       setLEDcol(128, 128, strip.Color(255, 0, 0));  // S
-      setLEDcol(159, 159, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 6) {                     // GSW:
       setLEDcol(0, 3, strip.Color(255, 0, 0));    // ZIIT
-      setLEDcol(28, 31, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 7) {  // CN:
       setLEDcol(40, 41, strip.Color(255, 0, 0));
-      setLEDcol(54, 55, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 8) {                       // SWABIAN:
       setLEDcol(73, 74, strip.Color(255, 0, 0));    // ZE
-      setLEDcol(85, 86, strip.Color(255, 0, 0));    // 2nd row
       setLEDcol(131, 131, strip.Color(255, 0, 0));  // I
-      setLEDcol(156, 156, strip.Color(255, 0, 0));  // 2nd row
       setLEDcol(204, 204, strip.Color(255, 0, 0));  // T
-      setLEDcol(211, 211, strip.Color(255, 0, 0));  // 2nd row
     }
 
     if (langLEDlayout == 9) {                     // BAVARIAN:
       setLEDcol(5, 8, strip.Color(255, 0, 0));    // ZEID
-      setLEDcol(23, 26, strip.Color(255, 0, 0));  // 2nd row
     }
 
     strip.show();
@@ -3783,68 +3175,50 @@ void initTime(String timezone) {
   ClearDisplay();
   if (langLEDlayout == 0) {  // DE:
     setLEDcol(1, 4, strip.Color(0, 255, 0));
-    setLEDcol(27, 30, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 1) {  // EN:
     setLEDcol(33, 36, strip.Color(0, 255, 0));
-    setLEDcol(59, 62, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 2) {  // NL:
     setLEDcol(69, 72, strip.Color(0, 255, 0));
-    setLEDcol(87, 90, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 3) {  // SWE:
     setLEDcol(96, 98, strip.Color(0, 255, 0));
-    setLEDcol(125, 127, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 4) {                       // IT:
     setLEDcol(111, 111, strip.Color(0, 255, 0));  // T
-    setLEDcol(112, 112, strip.Color(0, 255, 0));  // 2nd row
     setLEDcol(96, 97, strip.Color(0, 255, 0));    // EM
-    setLEDcol(126, 127, strip.Color(0, 255, 0));  // 2nd row
     setLEDcol(131, 131, strip.Color(0, 255, 0));  // P
-    setLEDcol(156, 156, strip.Color(0, 255, 0));  // 2nd row
     setLEDcol(234, 234, strip.Color(0, 255, 0));  // O
-    setLEDcol(245, 245, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 5) {                       // FR:
     setLEDcol(10, 10, strip.Color(0, 255, 0));    // T
-    setLEDcol(21, 21, strip.Color(0, 255, 0));    // 2nd row
     setLEDcol(41, 42, strip.Color(0, 255, 0));    // EM
-    setLEDcol(53, 54, strip.Color(0, 255, 0));    // 2nd row
     setLEDcol(105, 105, strip.Color(0, 255, 0));  // p
-    setLEDcol(118, 118, strip.Color(0, 255, 0));  // 2nd row
     setLEDcol(128, 128, strip.Color(0, 255, 0));  // S
-    setLEDcol(159, 159, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 6) {                     // GSW:
     setLEDcol(0, 3, strip.Color(0, 255, 0));    // ZIIT
-    setLEDcol(28, 31, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 7) {  // CN:
     setLEDcol(40, 41, strip.Color(0, 255, 0));
-    setLEDcol(54, 55, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 8) {                       // SWABIAN:
     setLEDcol(73, 74, strip.Color(0, 255, 0));    // ZE
-    setLEDcol(85, 86, strip.Color(0, 255, 0));    // 2nd row
     setLEDcol(131, 131, strip.Color(0, 255, 0));  // I
-    setLEDcol(156, 156, strip.Color(0, 255, 0));  // 2nd row
     setLEDcol(204, 204, strip.Color(0, 255, 0));  // T
-    setLEDcol(211, 211, strip.Color(0, 255, 0));  // 2nd row
   }
 
   if (langLEDlayout == 9) {                     // BAVARIAN:
     setLEDcol(5, 8, strip.Color(0, 255, 0));    // ZEID
-    setLEDcol(23, 26, strip.Color(0, 255, 0));  // 2nd row
   }
 
   strip.show();
@@ -4238,83 +3612,50 @@ void SetWLAN(uint32_t color) {
   ClearDisplay();
 
   if (langLEDlayout == 0) {  // DE:
-    for (uint16_t i = 5; i < 9; i++) {
-      strip.setPixelColor(i, color);
-    }
-    for (uint16_t i = 23; i < 27; i++) {  // 2nd row
-      strip.setPixelColor(i, color);
-    }
+    setLEDcol(5, 8, color);   // WIFI
   }
 
   if (langLEDlayout == 1) {  // EN:
-    for (uint16_t i = 7; i < 11; i++) {
-      strip.setPixelColor(i, color);
-    }
-    for (uint16_t i = 21; i < 25; i++) {  // 2nd row
-      strip.setPixelColor(i, color);
-    }
+    setLEDcol(7, 10, color);   // WIFI
   }
 
   if (langLEDlayout == 2) {  // NL:
-    for (uint16_t i = 75; i < 79; i++) {
-      strip.setPixelColor(i, color);
-    }
-    for (uint16_t i = 81; i < 85; i++) {  // 2nd row
-      strip.setPixelColor(i, color);
-    }
+    setLEDcol(75, 78, color);   // WIFI
   }
 
   if (langLEDlayout == 3) {  // SWE:
-    for (uint16_t i = 0; i < 4; i++) {
-      strip.setPixelColor(i, color);
-    }
-    for (uint16_t i = 28; i < 32; i++) {  // 2nd row
-      strip.setPixelColor(i, color);
-    }
+    setLEDcol(0, 3, color);   // WIFI
   }
 
   if (langLEDlayout == 4) {      // IT:
     setLEDcol(233, 233, color);  // W
-    setLEDcol(246, 246, color);  // 2nd row
     setLEDcol(231, 231, color);  // I
-    setLEDcol(248, 248, color);  // 2nd row
     setLEDcol(226, 226, color);  // F
-    setLEDcol(253, 253, color);  // 2nd row
     setLEDcol(224, 224, color);  // I
-    setLEDcol(255, 255, color);  // 2nd row
   }
 
   if (langLEDlayout == 5) {      // FR:
     setLEDcol(239, 239, color);  // W
-    setLEDcol(240, 240, color);  // 2nd row
     setLEDcol(237, 237, color);  // I
-    setLEDcol(242, 242, color);  // 2nd row
     setLEDcol(232, 232, color);  // F
-    setLEDcol(247, 247, color);  // 2nd row
     setLEDcol(224, 224, color);  // I
-    setLEDcol(255, 255, color);  // 2nd row
   }
 
   if (langLEDlayout == 6) {    // GSW:
     setLEDcol(7, 10, color);   // WIFI
-    setLEDcol(21, 24, color);  // 2nd row
   }
 
   if (langLEDlayout == 7) {    // CN:
     setLEDcol(42, 43, color);  // WIFI
-    setLEDcol(52, 53, color);  // 2nd row
   }
 
   if (langLEDlayout == 8) {    // SWABIAN:
     setLEDcol(12, 13, color);  // WI
-    setLEDcol(18, 19, color);  // 2nd row
     setLEDcol(7, 8, color);    // FI
-    setLEDcol(23, 24, color);  // 2nd row
   }
 
   if (langLEDlayout == 9) {    // BAVARIAN:
     setLEDcol(10, 13, color);  // WIFI
-    setLEDcol(18, 21, color);  // 2nd row
   }
 
   strip.show();

--- a/Code/Code.ino
+++ b/Code/Code.ino
@@ -1271,7 +1271,7 @@ void ResetTextLEDs(uint32_t color) {
 // ###########################################################################################################################################
 void setLEDcol(int ledNrFrom, int ledNrTo, uint32_t color) {
   if (ledNrFrom > ledNrTo) {
-    setLED(ledNrTo, ledNrFrom, 1);  // Sets LED numbers in correct order
+    setLEDcol(ledNrTo, ledNrFrom, color);  // Sets LED numbers in correct order
   } else {
     for (int i = ledNrFrom; i <= ledNrTo; i++) {
       if ((i >= 0) && (i < NUMPIXELS))

--- a/Code/Code.ino
+++ b/Code/Code.ino
@@ -1267,17 +1267,32 @@ void ResetTextLEDs(uint32_t color) {
 
 
 // ###########################################################################################################################################
-// # Actual function, which controls 1/0 of the LED with color value:
+// # Actual function, which controls 1/0 of the LED and their sibling with color value:
 // ###########################################################################################################################################
 void setLEDcol(int ledNrFrom, int ledNrTo, uint32_t color) {
   if (ledNrFrom > ledNrTo) {
     setLEDcol(ledNrTo, ledNrFrom, color);  // Sets LED numbers in correct order
   } else {
     for (int i = ledNrFrom; i <= ledNrTo; i++) {
-      if ((i >= 0) && (i < NUMPIXELS))
+      if ((i >= 0) && (i < NUMPIXELS)) {
         strip.setPixelColor(i, color);
+        int pairedLED = getPairedLED(i);
+        if ((pairedLED >= 0) && (pairedLED < NUMPIXELS))
+          strip.setPixelColor(pairedLED, color);
+      }
     }
   }
+}
+
+
+// ###########################################################################################################################################
+// # Get the sibling led for a two-led lit character (with 32 leds / 16 chars per row):
+// ###########################################################################################################################################
+int getPairedLED(int ledNumber) {
+    const int ledsPerLine = ROWPIXELS * 2;
+    int row = ledNumber / ledsPerLine; 
+    int positionInRow = ledNumber % ledsPerLine;
+    return row * ledsPerLine + (ledsPerLine - 1 - positionInRow);
 }
 
 
@@ -3644,8 +3659,12 @@ void setLED(int ledNrFrom, int ledNrTo, int switchOn) {
     setLED(ledNrTo, ledNrFrom, switchOn);  // Sets LED numbers in correct order
   } else {
     for (int i = ledNrFrom; i <= ledNrTo; i++) {
-      if ((i >= 0) && (i < NUMPIXELS))
+      if ((i >= 0) && (i < NUMPIXELS)) {
         strip.setPixelColor(i, strip.Color(redVal_time, greenVal_time, blueVal_time));
+        int pairedLED = getPairedLED(i);
+        if ((pairedLED >= 0) && (pairedLED < NUMPIXELS))
+          strip.setPixelColor(pairedLED, strip.Color(redVal_time, greenVal_time, blueVal_time));  
+      }
     }
   }
   if (switchOn == 0) {

--- a/Code/settings.h
+++ b/Code/settings.h
@@ -54,6 +54,7 @@ int langLEDlayout_default = 0;
 // ###########################################################################################################################################
 #define LEDPIN 32      // Arduino-Pin connected to the NeoPixels
 #define NUMPIXELS 256  // How many NeoPixels are attached to the Arduino
+#define ROWPIXELS 16  // How many NeoPixels per row
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(NUMPIXELS, LEDPIN, NEO_GRB + NEO_KHZ800);
 
 


### PR DESCRIPTION
I was tired of looking up the correspondent second row leds and constantly mistyping the numbers, so I thought there would be a nicer way to do this trick.

My PR adds a method that calculates the second row led (aka sibling). I extended the setLED() and setLEDcol() methods to retrieve this information and subsequently removed all second row calls to these methods.

Hope it helps!